### PR TITLE
Remove problematic package libnss-mdns

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -8,13 +8,14 @@ sudo rm -rf /usr/share/lintian/* /usr/share/linda/* /var/cache/man/*
 
 # Install additional software
 
-# Remove unused packages
+# Remove unused packages or problematic packages
 ## Bluetooth
 sudo apt-get purge -y bluez \
   bluez-firmware \
   pi-bluetooth \
   samba-common \
-  nfs-common 
+  nfs-common \
+  libnss-mdns
 
 ## Compilers
 sudo apt-get purge -y gcc \


### PR DESCRIPTION
libnss-mdns was causing name resolution issues so I am removing it. libnss-mdns modifies /etc/nsswitch.conf and causes timeout issues when trying to lookup a hostname. nslookup works ok, it's ping and any application that attempts to look up a host that fails. The workaround was pulled from [here](https://askubuntu.com/questions/81797/nslookup-finds-ip-but-ping-doesnt).
